### PR TITLE
plagiarism_turnitin_users missing from privacy class

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -71,6 +71,14 @@ class provider implements
             'privacy:metadata:plagiarism_turnitin_files'
         );
 
+        $collection->add_database_table(
+            'plagiarism_turnitin_users',
+            [
+                'userid' => 'privacy:metadata:plagiarism_turnitin_users:userid',
+            ],
+            'privacy:metadata:plagiarism_turnitin_users'
+        );
+
         $collection->link_external_location('plagiarism_turnitin_client', [
             'email' => 'privacy:metadata:plagiarism_turnitin_client:email',
             'firstname' => 'privacy:metadata:plagiarism_turnitin_client:firstname',

--- a/lang/en/plagiarism_turnitin.php
+++ b/lang/en/plagiarism_turnitin.php
@@ -273,6 +273,9 @@ $string['privacy:metadata:plagiarism_turnitin_client:submission_title'] = 'The t
 $string['privacy:metadata:plagiarism_turnitin_client:submission_filename'] = 'The name of the submitted file is sent to Turntin so that it is identifiable.';
 $string['privacy:metadata:plagiarism_turnitin_client:submission_content'] = 'Please be aware that the content of a file/submission is sent to Turnitin for processing.';
 
+$string['privacy:metadata:plagiarism_turnitin_users'] = 'Information about Plagiarism Plugin Users.';
+$string['privacy:metadata:plagiarism_turnitin_users:userid'] = 'The ID of the user who uses this plugin.';
+
 $string['privacy:metadata:core_files'] = 'Turnitin Assignment stores files that have been uploaded to Moodle to form a Turnitin submission.';
 
 $string['errorcode13'] = 'This submissionid - {$a->externalid} was not found in Turnitin. Unable to retrieve similarity score and other submission data.';

--- a/tests/privacy/provider_test.php
+++ b/tests/privacy/provider_test.php
@@ -51,7 +51,7 @@ class plagiarism_turnitin_privacy_provider_testcase extends \core_privacy\tests\
         $newcollection = provider::get_metadata($collection);
         $itemcollection = $newcollection->get_collection();
 
-        $this->assertCount(3, $itemcollection);
+        $this->assertCount(4, $itemcollection);
 
         // Verify core_files data is returned.
         $this->assertEquals('core_files', $itemcollection[0]->get_name());
@@ -72,9 +72,9 @@ class plagiarism_turnitin_privacy_provider_testcase extends \core_privacy\tests\
         $this->assertArrayHasKey('student_read', $privacyfields);
 
         // Verify plagiarism_turnitin_client data is returned.
-        $this->assertEquals('plagiarism_turnitin_client', $itemcollection[2]->get_name());
+        $this->assertEquals('plagiarism_turnitin_client', $itemcollection[3]->get_name());
 
-        $privacyfields = $itemcollection[2]->get_privacy_fields();
+        $privacyfields = $itemcollection[3]->get_privacy_fields();
         $this->assertArrayHasKey('email', $privacyfields);
         $this->assertArrayHasKey('firstname', $privacyfields);
         $this->assertArrayHasKey('lastname', $privacyfields);
@@ -82,7 +82,7 @@ class plagiarism_turnitin_privacy_provider_testcase extends \core_privacy\tests\
         $this->assertArrayHasKey('submission_filename', $privacyfields);
         $this->assertArrayHasKey('submission_content', $privacyfields);
 
-        $this->assertEquals('privacy:metadata:plagiarism_turnitin_client', $itemcollection[2]->get_summary());
+        $this->assertEquals('privacy:metadata:plagiarism_turnitin_client', $itemcollection[3]->get_summary());
     }
 
     /**


### PR DESCRIPTION
We want to add that is causing `vendor/bin/phpunit "provider_testcase" privacy/tests/provider_test.php` unit test fail.