### PR TITLE
Update to the latest version and fix unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+### Date:	    2023-March-30
+### Release:	v2023033001
+
+#### Students that have previously rejected the EULA can now resubmit
+
+We have fixed an issue that was preventing students from being able to resubmit to Turnitin for an assignment where they had previously rejected the EULA. Now if a student accepts the EULA, they will be able to successfully resubmit to any assignments where they previously rejected the EULA.
+
+#### Inbox now displays the highest score when Translated Matching is enabled
+
+We have fixed an issue with the similarity score value in the Moodle Plagiarism Plugin inbox. Previously it wasn't updating with the highest score when translated matching was enabled, and instead the inbox continued to display the first score, even if it was the lower of the two.
+
+#### Duplicate quiz responses are now handled separately
+
+We have fixed an issue where if a student submitted the same response multiple times on a quiz, all duplicate responses would be linked to same report, which would not allow them to be reviewed by an instructor as separate responses. Each response now generates a separate report.
+
+---
+
 ### Date:       2022-September-21
 ### Release:    v2022092101
 

--- a/classes/modules/turnitin_quiz.class.php
+++ b/classes/modules/turnitin_quiz.class.php
@@ -82,7 +82,7 @@ class turnitin_quiz {
         foreach ($attempt->get_slots() as $slot) {
             $answer = $attempt->get_question_attempt($slot)->get_response_summary();
             // Check if this is the slot the mark is for by matching content.
-            if (sha1($answer) == $identifier) {
+            if (sha1($answer.$slot) == $identifier) {
                 // Translate the TFS grade to a mark for the question.
                 $questionmaxmark = $attempt->get_question_attempt($slot)->get_max_mark();
 

--- a/classes/modules/turnitin_quiz.class.php
+++ b/classes/modules/turnitin_quiz.class.php
@@ -82,7 +82,8 @@ class turnitin_quiz {
         foreach ($attempt->get_slots() as $slot) {
             $answer = $attempt->get_question_attempt($slot)->get_response_summary();
             // Check if this is the slot the mark is for by matching content.
-            if (sha1($answer.$slot) == $identifier) {
+            $answerslot = $answer ? $answer.$slot : $answer;
+            if (sha1($answerslot) == $identifier) {
                 // Translate the TFS grade to a mark for the question.
                 $questionmaxmark = $attempt->get_question_attempt($slot)->get_max_mark();
 

--- a/lib.php
+++ b/lib.php
@@ -2307,8 +2307,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $coursedata = $this->get_course_data($cm->id, $cm->course);
         $user = new turnitin_user($author, "Learner");
         $user->join_user_to_class($coursedata->turnitin_cid);
-        $eulaaccepted = ($user->useragreementaccepted == 0) ? $user->get_accepted_user_agreement() : $user->useragreementaccepted;
-        if ($eulaaccepted != 1) {
+        $eula_accepted = ($user->useragreementaccepted == 0) ? $user->get_accepted_user_agreement() : $user->useragreementaccepted;
+        if ($eula_accepted != 1) {
             return true;
         }
         // Check if file has been submitted before.

--- a/lib.php
+++ b/lib.php
@@ -767,7 +767,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     $submissiontype = 'quiz_answer';
                 }
                 $content = $moduleobject->set_content($linkarray, $cm);
-                $identifier = sha1($content);
+                $identifier = ($submissiontype === 'quiz_answer') ? sha1($content.$linkarray["itemid"]) : sha1($content);
             }
 
             // Group submissions where all students have to submit sets userid to 0.
@@ -2582,7 +2582,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 $eventdata['other']['content'] = $qa->get_response_summary();
 
                 // Queue text content.
-                $identifier = sha1($eventdata['other']['content']);
+                // adding slot to sha hash to create unique assignments for duplicate text based on it's id
+                $identifier = sha1($eventdata['other']['content'].$slot);
                 $result = $this->queue_submission_to_turnitin(
                         $cm, $author, $submitter, $identifier, 'quiz_answer',
                         $eventdata['objectid'], $eventdata['eventtype']);
@@ -3155,7 +3156,7 @@ function plagiarism_turnitin_send_queued_submissions() {
                 }
                 foreach ($attempt->get_slots() as $slot) {
                     $qa = $attempt->get_question_attempt($slot);
-                    if ($queueditem->identifier == sha1($qa->get_response_summary())) {
+                    if ($queueditem->identifier == sha1($qa->get_response_summary().$slot)) {
                         $textcontent = $qa->get_response_summary();
                         break;
                     }

--- a/lib.php
+++ b/lib.php
@@ -2303,6 +2303,14 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $attempt = 0;
         $tiisubmissionid = null;
 
+        // If the EULA hasn't been accepted, don't save submission and don't submit to Tii
+        $coursedata = $this->get_course_data($cm->id, $cm->course);
+        $user = new turnitin_user($author, "Learner");
+        $user->join_user_to_class($coursedata->turnitin_cid);
+        $eulaaccepted = ($user->useragreementaccepted == 0) ? $user->get_accepted_user_agreement() : $user->useragreementaccepted;
+        if ($eulaaccepted != 1) {
+            return true;
+        }
         // Check if file has been submitted before.
         $plagiarismfiles = plagiarism_turnitin_retrieve_successful_submissions($author, $cm->id, $identifier);
         if (count($plagiarismfiles) > 0) {

--- a/vendor/Integrations/phpsdk-package/src/SubmissionSoap.php
+++ b/vendor/Integrations/phpsdk-package/src/SubmissionSoap.php
@@ -40,13 +40,17 @@ class SubmissionSoap extends Soap
                 );
             } else {
                 $tiiSubmission = new TiiSubmission();
+                $translatedScore = null;
                 $tiiSubmission->setSubmissionId($soap->resultRecord->sourcedGUID->sourcedId);
                 $tiiSubmission->setTitle($soap->resultRecord->result->resultValue->label);
                 $tiiSubmission->setAssignmentId($soap->resultRecord->result->lineItemSourcedId);
                 $tiiSubmission->setAuthorUserId($soap->resultRecord->result->personSourcedId);
                 $tiiSubmission->setDate($soap->resultRecord->result->date);
                 $tiiSubmission->setOverallSimilarity($soap->resultRecord->result->resultScore->textString);
-                $tiiSubmission->setTranslatedOverallSimilarity($soap->resultRecord->result->extension->extensionField[6]->fieldValue);
+                $translatedScore = $this->checkForTranslatedSimScore($soap->resultRecord->result->extension->extensionField);
+                if (!is_null($translatedScore)) {
+                    $tiiSubmission->setTranslatedOverallSimilarity($translatedScore);
+                }
                 foreach ($soap->resultRecord->result->extension->extensionField as $field) {
                     $name = $field->fieldName;
                     $method = 'set'.$name;
@@ -90,6 +94,7 @@ class SubmissionSoap extends Soap
                 );
             } else {
                 $submissions = array();
+                $translatedScore = null;
                 if (isset($soap->resultRecordSet->resultRecord)) {
                     if (!is_array($soap->resultRecordSet->resultRecord)) {
                         $soap->resultRecordSet->resultRecord = array($soap->resultRecordSet->resultRecord);
@@ -102,7 +107,10 @@ class SubmissionSoap extends Soap
                         $tiiSubmission->setAuthorUserId($submission->result->personSourcedId);
                         $tiiSubmission->setDate($submission->result->date);
                         $tiiSubmission->setOverallSimilarity($submission->result->resultScore->textString);
-                        $tiiSubmission->setTranslatedOverallSimilarity($submission->result->extension->extensionField[6]->fieldValue);
+                        $translatedScore = $this->checkForTranslatedSimScore($submission->result->extension->extensionField);
+                        if (!is_null($translatedScore)) {
+                            $tiiSubmission->setTranslatedOverallSimilarity($translatedScore);
+                        }
                         foreach ($submission->result->extension->extensionField as $field) {
                             $name = $field->fieldName;
                             $method = 'set'.$name;
@@ -360,5 +368,18 @@ class SubmissionSoap extends Soap
         }
 
         return $request;
+    }
+
+    /**
+     * @param $array
+     * @return string
+     */
+    private function checkForTranslatedSimScore($array) {
+        foreach ($array as $object) {
+            if ( ($object->fieldName == "TranslatedOverallSimilarity") && (!is_null($object->fieldValue)) ) {
+                return $object->fieldValue;
+            }
+        }
+        return null;
     }
 }

--- a/vendor/Integrations/phpsdk-package/src/SubmissionSoap.php
+++ b/vendor/Integrations/phpsdk-package/src/SubmissionSoap.php
@@ -46,6 +46,7 @@ class SubmissionSoap extends Soap
                 $tiiSubmission->setAuthorUserId($soap->resultRecord->result->personSourcedId);
                 $tiiSubmission->setDate($soap->resultRecord->result->date);
                 $tiiSubmission->setOverallSimilarity($soap->resultRecord->result->resultScore->textString);
+                $tiiSubmission->setTranslatedOverallSimilarity($soap->resultRecord->result->extension->extensionField[6]->fieldValue);
                 foreach ($soap->resultRecord->result->extension->extensionField as $field) {
                     $name = $field->fieldName;
                     $method = 'set'.$name;
@@ -101,6 +102,7 @@ class SubmissionSoap extends Soap
                         $tiiSubmission->setAuthorUserId($submission->result->personSourcedId);
                         $tiiSubmission->setDate($submission->result->date);
                         $tiiSubmission->setOverallSimilarity($submission->result->resultScore->textString);
+                        $tiiSubmission->setTranslatedOverallSimilarity($submission->result->extension->extensionField[6]->fieldValue);
                         foreach ($submission->result->extension->extensionField as $field) {
                             $name = $field->fieldName;
                             $method = 'set'.$name;

--- a/version.php
+++ b/version.php
@@ -19,7 +19,7 @@
  * @copyright 2012 iParadigms LLC
  */
 
-$plugin->version = 2022092101;
+$plugin->version = 2023033001;
 
 $plugin->release = "3.5+";
 $plugin->requires = 2018051700;


### PR DESCRIPTION
Updates were causing the following unit test to fail
```
vendor/bin/phpunit --testsuite plagiarism_turnitin_testsuite
Moodle 3.9.20+ (Build: 20230406), 19730ad7a207ba033d5af8c36fa0b0e286f6259a
Php: 7.4.33, mysqli: 5.7.39, OS: Linux 5.19.0-38-generic x86_64
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

.....................F......                                      28 / 28 (100%)
Time: 13.61 seconds, Memory: 109.00 MB

There was 1 failure:

1) plagiarism_turnitin_quiz_testcase::test_update_mark
Failed asserting that '0.00000' matches expected 0.75.

```