### PR TITLE
Update plagiarism_turnitin_quiz_testcase::test_update_mark

### DIFF
--- a/classes/modules/turnitin_quiz.class.php
+++ b/classes/modules/turnitin_quiz.class.php
@@ -82,8 +82,7 @@ class turnitin_quiz {
         foreach ($attempt->get_slots() as $slot) {
             $answer = $attempt->get_question_attempt($slot)->get_response_summary();
             // Check if this is the slot the mark is for by matching content.
-            $answerslot = $answer ? $answer.$slot : $answer;
-            if (sha1($answerslot) == $identifier) {
+            if (sha1($answer.$slot) == $identifier) {
                 // Translate the TFS grade to a mark for the question.
                 $questionmaxmark = $attempt->get_question_attempt($slot)->get_max_mark();
 

--- a/tests/modules/turnitin_quiz_test.php
+++ b/tests/modules/turnitin_quiz_test.php
@@ -81,7 +81,8 @@ class plagiarism_turnitin_quiz_testcase extends advanced_testcase {
         // Now update the grade of the essay question through the Turnitin quiz class.
         $tiiquiz = new turnitin_quiz;
         $answer = $attemptobj->get_question_attempt(1)->get_response_summary();
-        $identifier = sha1($answer);
+        $slot = 1;
+        $identifier = sha1($answer.$slot);
         $tiiquiz->update_mark($attempt->id, $identifier, $user->id, 75, $quiz->grade);
 
         // Reload the attempt and check the total marks and grade are as we expect it.


### PR DESCRIPTION
https://github.com/turnitin/moodle-plagiarism_turnitin/pull/648/ changed `update_mark` such that it appends the question slot when calculating the hash. They updated all places in code to append the slot, except for `plagiarism_turnitin_quiz_testcase::test_update_mark` - see https://github.com/turnitin/moodle-plagiarism_turnitin/issues/664

We fixed this buy changing the behaviour of `update_mark` in a way that does make the test pass, but is a bit brittle and may introduce regressions. Instead we should modify the test.