### PR TITLE
Fix: Return type for Integrations\PhpSdk\Soap::__doRequest() (#702)

### DIFF
--- a/vendor/Integrations/phpsdk-package/src/Soap.php
+++ b/vendor/Integrations/phpsdk-package/src/Soap.php
@@ -366,7 +366,7 @@ class Soap extends \SoapClient
      * @return mixed|string
      * @throws TurnitinSDKException
      */
-    public function __doRequest($request, $location, $action, $version, $one_way = null)
+    public function __doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false): ?string {
     {
 
         $http_headers = array(


### PR DESCRIPTION
Reflects it's extended class SoapClient: https://www.php.net/manual/en/soapclient.dorequest.php

Resolves #702