### PR TITLE
Revert "Update deprecated unit test method"

### DIFF
--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -226,6 +226,6 @@ class plagiarism_turnitin_lib_testcase extends advanced_testcase {
         // Get the config.
         $config = $plagiarismturnitin->plagiarism_turnitin_admin_config();
 
-        $this->assertObjectNotHasProperty("plagiarism_turnitin_test", $config);
+        $this->assertObjectNotHasAttribute("plagiarism_turnitin_test", $config);
     }
 }


### PR DESCRIPTION
This reverts commit 44d0c64f8ffbb600b6af1730a00d05c10c21c5c0.


https://github.com/sebastianbergmann/phpunit/issues/5478

To summarize, PHP unit 9.6 has assertObjectNotHasAttribute() deprecated and replaced it with assertObjectNotHasProperty() 
However, moodle 4.1 is only compatible with phpunit 9.5.* https://github.com/moodle/moodle/blob/MOODLE_401_STABLE/composer.json#L8