### PR TITLE
issue #949: default settings per mod type

### DIFF
--- a/classes/forms/turnitin_defaultsettingsform.class.php
+++ b/classes/forms/turnitin_defaultsettingsform.class.php
@@ -38,10 +38,13 @@ class turnitin_defaultsettingsform extends moodleform {
 
         $mform = $this->_form;
 
+        // Read the module name from custom data passed by settings.php.
+        $modulename = !empty($this->_customdata['modulename']) ? $this->_customdata['modulename'] : '';
+
         require_once($CFG->dirroot.'/plagiarism/turnitin/classes/turnitin_view.class.php');
 
         $turnitinview = new turnitin_view();
-        $turnitinview->add_elements_to_settings_form($mform, [], "defaults");
+        $turnitinview->add_elements_to_settings_form($mform, [], "defaults", $modulename);
 
         $this->add_action_buttons(true);
     }

--- a/classes/forms/turnitin_setupform.class.php
+++ b/classes/forms/turnitin_setupform.class.php
@@ -55,17 +55,18 @@ class turnitin_setupform extends moodleform {
         $mform->addElement('html', get_string('tiiexplain', 'plagiarism_turnitin').'</br></br>');
 
         // Loop through all modules that support Plagiarism.
-        $mods = array_keys(core_component::get_plugin_list('mod'));
+        $plagiarismturnitin = new plagiarism_plugin_turnitin();
+        $mods = $plagiarismturnitin->get_plagiarism_supported_modules();
         foreach ($mods as $mod) {
-            if (plugin_supports('mod', $mod, FEATURE_PLAGIARISM)) {
-                $mform->addElement('advcheckbox',
-                    'plagiarism_turnitin_mod_'.$mod,
-                    get_string('useturnitin_mod', 'plagiarism_turnitin', ucfirst($mod)),
-                    '',
-                    null,
-                    [0, 1]
-                );
-            }
+            $displayname = get_string('pluginname', $mod);
+            $mform->addElement(
+                'advcheckbox',
+                'plagiarism_turnitin_' . $mod,
+                get_string('useturnitin_mod', 'plagiarism_turnitin', $displayname),
+                '',
+                null,
+                [0, 1]
+            );
         }
 
         $mform->addElement('header', 'plagiarism_turnitinconfig', get_string('tiiaccountconfig',

--- a/classes/turnitin_view.class.php
+++ b/classes/turnitin_view.class.php
@@ -99,7 +99,7 @@ class turnitin_view {
 
         $tabs = [];
         foreach ($enabledmods as $mod) {
-            $displayname = get_string('pluginname', $mod);
+            $displayname = ucfirst(preg_replace('/^mod_/', '', $mod));
             $tabs[] = new tabobject(
                 'defaults_' . $mod,
                 $CFG->wwwroot . '/plagiarism/turnitin/settings.php?do=defaults&modulename=' . $mod,
@@ -297,11 +297,10 @@ class turnitin_view {
             if ($mform->elementExists('submissiondrafts') || $location == 'defaults') {
                 // Only show draft submit option for modules that support draft submissions.
                 // At activity level it is always shown when the submissiondrafts element exists.
-                // At defaults level, only show for modules known to support draft submissions.
-                $modulessupportingdrafts = ['mod_assign', 'mod_coursework'];
+                // At defaults level, check the module's DB table for a submissiondrafts column.
                 $showdraftsubmit = ($location != 'defaults')
                     || empty($modulename)
-                    || in_array($modulename, $modulessupportingdrafts);
+                    || plagiarism_plugin_turnitin::module_supports_submission_drafts($modulename);
 
                 if ($showdraftsubmit) {
                     $tiidraftoptions = [0 => get_string("submitondraft", "plagiarism_turnitin"),

--- a/classes/turnitin_view.class.php
+++ b/classes/turnitin_view.class.php
@@ -82,13 +82,44 @@ class turnitin_view {
     }
 
     /**
+     * Prints the sub-tab menu for the Default Settings page, one tab per enabled module.
+     *
+     * @param string $modulename The currently active module type tab.
+     */
+    public function draw_defaults_subtab_menu($modulename) {
+        global $CFG, $OUTPUT;
+
+        // Enabled module which support plagiarism.
+        $enabledmods = plagiarism_plugin_turnitin::get_enabled_supported_modules();
+
+        if (empty($enabledmods)) {
+            echo $OUTPUT->notification(get_string('noenabledmodules', 'plagiarism_turnitin'), 'info');
+            return;
+        }
+
+        $tabs = [];
+        foreach ($enabledmods as $mod) {
+            $displayname = get_string('pluginname', $mod);
+            $tabs[] = new tabobject(
+                'defaults_' . $mod,
+                $CFG->wwwroot . '/plagiarism/turnitin/settings.php?do=defaults&modulename=' . $mod,
+                $displayname,
+                $displayname,
+                false
+            );
+        }
+
+        print_tabs([$tabs], 'defaults_' . $modulename);
+    }
+
+    /**
      * Due to moodle's internal plugin hooks we can not use our bespoke form class for Turnitin
      * settings. This form shows in settings > defaults as well as the activity creation screen.
      *
      * @param moodleform $mform The form object
      * @param object $course The course object
      * @param string $location The location of the form
-     * @param string $modulename The name of the module
+     * @param string $modulename The module name with 'mod_' prefix, e.g. 'mod_assign'
      * @param int $cmid The course module id
      * @param int $currentrubric The current rubric id
      * @return void
@@ -140,7 +171,12 @@ class turnitin_view {
                             2 => get_string('excludepercent', 'plagiarism_turnitin'), ];
 
         if ($location == "defaults") {
-            $mform->addElement('header', 'turnitin_plugin_header', get_string('turnitindefaults', 'plagiarism_turnitin'));
+            // Retrieve the human-readable module name from Moodle's language strings.
+            $displayname = !empty($modulename) ? get_string('pluginname', $modulename) : '';
+            $heading = empty($modulename)
+                ? get_string('turnitindefaults', 'plagiarism_turnitin')
+                : get_string('defaultsformodule', 'plagiarism_turnitin', $displayname);
+            $mform->addElement('header', 'turnitin_plugin_header', $heading);
             $mform->addElement('html', get_string("defaultsdesc", "plagiarism_turnitin"));
         }
 
@@ -229,7 +265,25 @@ class turnitin_view {
             }
         }
 
-        $locks = $DB->get_records_sql("SELECT name, value FROM {plagiarism_turnitin_config} WHERE cm IS NULL");
+
+        $alllocks = $DB->get_records_sql("SELECT name, value FROM {plagiarism_turnitin_config} WHERE cm IS NULL");
+
+        // If we know the module type, filter the global lock records to only those
+        // prefixed with that module type and strip the prefix, so lock() can look
+        // up plain field names like 'use_turnitin_lock'.
+        if (!empty($modulename)) {
+            $lockprefix = $modulename . '_';
+            $lockprefixlen = strlen($lockprefix);
+            $locks = [];
+            foreach ($alllocks as $name => $record) {
+                if (strpos($name, $lockprefix) === 0) {
+                    $unprefixedname = substr($name, $lockprefixlen);
+                    $locks[$unprefixedname] = $record;
+                }
+            }
+        } else {
+            $locks = $alllocks;
+        }
 
         if (empty($configwarning)) {
             $mform->addElement('select', 'use_turnitin', get_string("useturnitin", "plagiarism_turnitin"), $options);
@@ -241,13 +295,23 @@ class turnitin_view {
             $mform->addHelpButton('plagiarism_show_student_report', 'studentreports', 'plagiarism_turnitin');
 
             if ($mform->elementExists('submissiondrafts') || $location == 'defaults') {
-                $tiidraftoptions = [0 => get_string("submitondraft", "plagiarism_turnitin"),
-                                         1 => get_string("submitonfinal", "plagiarism_turnitin"), ];
+                // Only show draft submit option for modules that support draft submissions.
+                // At activity level it is always shown when the submissiondrafts element exists.
+                // At defaults level, only show for modules known to support draft submissions.
+                $modulessupportingdrafts = ['mod_assign', 'mod_coursework'];
+                $showdraftsubmit = ($location != 'defaults')
+                    || empty($modulename)
+                    || in_array($modulename, $modulessupportingdrafts);
 
-                $mform->addElement('select', 'plagiarism_draft_submit', get_string("draftsubmit",
-                    "plagiarism_turnitin"), $tiidraftoptions);
-                $this->lock($mform, $location, $locks);
-                $mform->disabledIf('plagiarism_draft_submit', 'submissiondrafts', 'eq', 0);
+                if ($showdraftsubmit) {
+                    $tiidraftoptions = [0 => get_string("submitondraft", "plagiarism_turnitin"),
+                                             1 => get_string("submitonfinal", "plagiarism_turnitin"), ];
+
+                    $mform->addElement('select', 'plagiarism_draft_submit', get_string("draftsubmit",
+                        "plagiarism_turnitin"), $tiidraftoptions);
+                    $this->lock($mform, $location, $locks);
+                    $mform->disabledIf('plagiarism_draft_submit', 'submissiondrafts', 'eq', 0);
+                }
             }
 
             $mform->addElement('select', 'plagiarism_allow_non_or_submissions', get_string("allownonor",
@@ -395,6 +459,11 @@ class turnitin_view {
 
             $mform->addElement('hidden', 'action', "defaults");
             $mform->setType('action', PARAM_RAW);
+
+            if ($location == 'defaults' && !empty($modulename)) {
+                $mform->addElement('hidden', 'modulename', $modulename);
+                $mform->setType('modulename', PARAM_ALPHANUMEXT);
+            }
         } else {
             $mform->addElement('hidden', 'use_turnitin', 0);
             $mform->setType('use_turnitin', PARAM_INT);

--- a/classes/turnitin_view.class.php
+++ b/classes/turnitin_view.class.php
@@ -90,7 +90,8 @@ class turnitin_view {
         global $CFG, $OUTPUT;
 
         // Enabled module which support plagiarism.
-        $enabledmods = plagiarism_plugin_turnitin::get_enabled_supported_modules();
+        $plagiarismturnitin = new plagiarism_plugin_turnitin();
+        $enabledmods = $plagiarismturnitin->get_enabled_supported_modules();
 
         if (empty($enabledmods)) {
             echo $OUTPUT->notification(get_string('noenabledmodules', 'plagiarism_turnitin'), 'info');
@@ -99,7 +100,7 @@ class turnitin_view {
 
         $tabs = [];
         foreach ($enabledmods as $mod) {
-            $displayname = ucfirst(preg_replace('/^mod_/', '', $mod));
+            $displayname = get_string('pluginname', $mod);
             $tabs[] = new tabobject(
                 'defaults_' . $mod,
                 $CFG->wwwroot . '/plagiarism/turnitin/settings.php?do=defaults&modulename=' . $mod,
@@ -300,7 +301,7 @@ class turnitin_view {
                 // At defaults level, check the module's DB table for a submissiondrafts column.
                 $showdraftsubmit = ($location != 'defaults')
                     || empty($modulename)
-                    || plagiarism_plugin_turnitin::module_supports_submission_drafts($modulename);
+                    || $plagiarismturnitin->module_supports_submission_drafts($modulename);
 
                 if ($showdraftsubmit) {
                     $tiidraftoptions = [0 => get_string("submitondraft", "plagiarism_turnitin"),

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -599,6 +599,89 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026060201.03, 'plagiarism', 'turnitin');
     }
 
+    if ($oldversion < 2026062400.01) {
+        // Migrate global default settings to per-module-type prefixed records.
+        // For every module that supports FEATURE_PLAGIARISM, copy all existing
+        // cm=NULL global defaults into new {modtype}_{fieldname} records so each
+        // module type can have its own independent defaults going forward.
+        // The original un-prefixed records are then deleted.
+        //
+        // Only the fields that belong to the Default Settings tab are touched;
+        // any other cm=NULL records (e.g. internal config values) are left alone.
+        $turnitinplugin = new plagiarism_plugin_turnitin();
+        $defaultsettingsfields = $turnitinplugin->get_settings_fields();
+        // The locked-message field which is saved alongside them but not part of
+        // the method's return value.
+        $defaultsettingsfields[] = 'plagiarism_locked_message';
+
+        // Build the full whitelist: each field plus its _lock companion.
+        $allowedfields = [];
+        foreach ($defaultsettingsfields as $field) {
+            $allowedfields[] = $field;
+            $allowedfields[] = $field . '_lock';
+        }
+        $allowedfields = array_unique($allowedfields);
+
+        // Fetch only the cm=NULL records that belong to the Default Settings tab.
+        $existingdefaults = $DB->get_records('plagiarism_turnitin_config', ['cm' => null]);
+        $existingdefaults = array_filter($existingdefaults, function($record) use ($allowedfields) {
+            return in_array($record->name, $allowedfields);
+        });
+
+        $supportedmods = plagiarism_plugin_turnitin::get_plagiarism_supported_modules();
+
+        // Build a set of known module prefixes so we can skip already-migrated records.
+        $modprefixes = [];
+        foreach ($supportedmods as $mod) {
+            $modprefixes[] = $mod . '_';
+        }
+
+        foreach ($supportedmods as $mod) {
+            foreach ($existingdefaults as $record) {
+                // Skip records that are already prefixed with any supported module name.
+                $alreadyprefixed = false;
+                foreach ($modprefixes as $prefix) {
+                    if (strpos($record->name, $prefix) === 0) {
+                        $alreadyprefixed = true;
+                        break;
+                    }
+                }
+                if ($alreadyprefixed) {
+                    continue;
+                }
+
+                $newname = $mod . '_' . $record->name;
+
+                // Only insert if the per-modtype record does not already exist.
+                if (!$DB->record_exists('plagiarism_turnitin_config', ['cm' => null, 'name' => $newname])) {
+                    $newrecord = new stdClass();
+                    $newrecord->cm = null;
+                    $newrecord->name = $newname;
+                    $newrecord->value = $record->value;
+                    $newrecord->config_hash = 'null_' . $newname;
+                    $DB->insert_record('plagiarism_turnitin_config', $newrecord);
+                }
+            }
+        }
+
+        // Delete the original un-prefixed Default Settings records now that every
+        // supported module type has its own prefixed copy.
+        foreach ($existingdefaults as $record) {
+            $alreadyprefixed = false;
+            foreach ($modprefixes as $prefix) {
+                if (strpos($record->name, $prefix) === 0) {
+                    $alreadyprefixed = true;
+                    break;
+                }
+            }
+            if (!$alreadyprefixed) {
+                $DB->delete_records('plagiarism_turnitin_config', ['id' => $record->id]);
+            }
+        }
+
+        upgrade_plugin_savepoint(true, 2026062400.01, 'plagiarism', 'turnitin');
+    }
+
     return $result;
 }
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -599,7 +599,7 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026060201.03, 'plagiarism', 'turnitin');
     }
 
-    if ($oldversion < 2026062400.01) {
+    if ($oldversion < 2026060201.04) {
         // Migrate global default settings to per-module-type prefixed records.
         // For every module that supports FEATURE_PLAGIARISM, copy all existing
         // cm=NULL global defaults into new {modtype}_{fieldname} records so each
@@ -608,11 +608,25 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
         //
         // Only the fields that belong to the Default Settings tab are touched;
         // any other cm=NULL records (e.g. internal config values) are left alone.
-        $turnitinplugin = new plagiarism_plugin_turnitin();
-        $defaultsettingsfields = $turnitinplugin->get_settings_fields();
-        // The locked-message field which is saved alongside them but not part of
-        // the method's return value.
-        $defaultsettingsfields[] = 'plagiarism_locked_message';
+        $defaultsettingsfields = [
+            'use_turnitin',
+            'plagiarism_show_student_report',
+            'plagiarism_draft_submit',
+            'plagiarism_allow_non_or_submissions',
+            'plagiarism_submitpapersto',
+            'plagiarism_compare_student_papers',
+            'plagiarism_compare_internet',
+            'plagiarism_compare_journals',
+            'plagiarism_report_gen',
+            'plagiarism_compare_institution',
+            'plagiarism_exclude_biblio',
+            'plagiarism_exclude_quoted',
+            'plagiarism_exclude_matches',
+            'plagiarism_exclude_matches_value',
+            'plagiarism_rubric',
+            'plagiarism_transmatch',
+            'plagiarism_locked_message',
+        ];
 
         // Build the full whitelist: each field plus its _lock companion.
         $allowedfields = [];
@@ -624,11 +638,19 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
 
         // Fetch only the cm=NULL records that belong to the Default Settings tab.
         $existingdefaults = $DB->get_records('plagiarism_turnitin_config', ['cm' => null]);
-        $existingdefaults = array_filter($existingdefaults, function($record) use ($allowedfields) {
+        $existingdefaults = array_filter($existingdefaults, function ($record) use ($allowedfields) {
             return in_array($record->name, $allowedfields);
         });
 
-        $supportedmods = plagiarism_plugin_turnitin::get_plagiarism_supported_modules();
+         // Supported modules.
+        $allmodsinfo = core_component::get_plugin_list('mod');
+        $supportedmods = [];
+        foreach (array_keys($allmodsinfo) as $mod) {
+            if (plugin_supports('mod', $mod, FEATURE_PLAGIARISM)) {
+                $supportedmods[] = 'mod_' . $mod;
+            }
+        }
+        sort($supportedmods);
 
         // Build a set of known module prefixes so we can skip already-migrated records.
         $modprefixes = [];
@@ -638,27 +660,14 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
 
         foreach ($supportedmods as $mod) {
             foreach ($existingdefaults as $record) {
-                // Skip records that are already prefixed with any supported module name.
-                $alreadyprefixed = false;
-                foreach ($modprefixes as $prefix) {
-                    if (strpos($record->name, $prefix) === 0) {
-                        $alreadyprefixed = true;
-                        break;
-                    }
-                }
-                if ($alreadyprefixed) {
-                    continue;
-                }
-
                 $newname = $mod . '_' . $record->name;
-
                 // Only insert if the per-modtype record does not already exist.
                 if (!$DB->record_exists('plagiarism_turnitin_config', ['cm' => null, 'name' => $newname])) {
                     $newrecord = new stdClass();
                     $newrecord->cm = null;
                     $newrecord->name = $newname;
                     $newrecord->value = $record->value;
-                    $newrecord->config_hash = 'null_' . $newname;
+                    $newrecord->config_hash = $newrecord->cm . "_" . $newrecord->name;
                     $DB->insert_record('plagiarism_turnitin_config', $newrecord);
                 }
             }
@@ -679,7 +688,7 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
             }
         }
 
-        upgrade_plugin_savepoint(true, 2026062400.01, 'plagiarism', 'turnitin');
+        upgrade_plugin_savepoint(true, 2026060201.04, 'plagiarism', 'turnitin');
     }
 
     return $result;

--- a/lang/en/plagiarism_turnitin.php
+++ b/lang/en/plagiarism_turnitin.php
@@ -96,6 +96,8 @@ $string['reportgenspeed_resubmission'] = 'You have already submitted a paper to 
 // Plugin settings.
 $string['config'] = 'Configuration';
 $string['defaults'] = 'Default Settings';
+$string['defaultsformodule'] = 'Default Settings for {$a}';
+$string['noenabledmodules'] = 'No modules are currently enabled for Turnitin. Please enable at least one module on the <a href="settings.php">Configuration</a> page.';
 $string['showusage'] = 'Show Data Dump';
 $string['saveusage'] = 'Save Data Dump';
 $string['errors'] = 'Errors';
@@ -324,3 +326,4 @@ $string['invalidtablename'] = 'Table {$a} could not be exported';
 $string['turnitin_cron_submissions_limit'] = 'Turnitin cron submissions limit';
 $string['turnitin_cron_submissions_cleanup'] = 'Turnitin cron submissions cleanup timeframe';
 $string['turnitin_cron_submissions_cleanup_desc'] = 'Cleanup task will reset all queued submissions that have not been sent after this period of time';
+$string['invalidmodtype'] = 'The specified module type is not an enabled supported module.';

--- a/lib.php
+++ b/lib.php
@@ -109,7 +109,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      */
     public function get_settings_fields(string $modulename = ''): array {
         $fields = [];
-        if (empty($modulename) || self::module_supports_submission_drafts($modulename)) {
+        if (empty($modulename) || $this->module_supports_submission_drafts($modulename)) {
             $fields[] = 'plagiarism_draft_submit';
         }
 
@@ -138,7 +138,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      *
      * @return string[] module names, e.g. ['mod_assign', 'mod_forum', ...]
      */
-    public static function get_plagiarism_supported_modules() {
+    public function get_plagiarism_supported_modules() {
         $mods = array_keys(core_component::get_plugin_list('mod'));
         $supported = [];
         foreach ($mods as $mod) {
@@ -156,8 +156,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      *
      * @return string[] enabled module names in component format, e.g. ['mod_assign', 'mod_forum']
      */
-    public static function get_enabled_supported_modules(): array {
-        $supported = self::get_plagiarism_supported_modules();
+    public function get_enabled_supported_modules(): array {
+        $supported = $this->get_plagiarism_supported_modules();
         $enabled = [];
         foreach ($supported as $mod) {
             if (get_config('plagiarism_turnitin', 'plagiarism_turnitin_' . $mod)) {
@@ -179,7 +179,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      * @param string $modulename Module name in component format, e.g. 'mod_assign'
      * @return array<string, mixed> field name => stored value
      */
-    public static function get_module_defaults(string $modulename): array {
+    public function get_module_defaults(string $modulename): array {
         global $DB;
         $prefix      = $modulename . '_';
         $prefixlen   = strlen($prefix);
@@ -204,7 +204,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      * @param string $modulename Module name in component format, e.g. 'mod_assign'
      * @return bool True if the module table has a submissiondrafts column.
      */
-    public static function module_supports_submission_drafts(string $modulename): bool {
+    public function module_supports_submission_drafts(string $modulename): bool {
         global $DB;
         $modname = preg_replace('/^mod_/', '', $modulename);
         if (empty($modname)) {
@@ -263,7 +263,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         if (!empty($modulename)) {
             // Per-module defaults.
-            $defaults = self::get_module_defaults($modulename);
+            $defaults = $this->get_module_defaults($modulename);
         } else {
             // All settings, includes all module defaults.
             $defaults = $DB->get_records_menu('plagiarism_turnitin_config', ['cm' => null], '', 'name,value');

--- a/lib.php
+++ b/lib.php
@@ -111,6 +111,67 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     }
 
     /**
+     * Get all installed modules that declare FEATURE_PLAGIARISM support.
+     * The list is sorted alphabetically for consistent tab ordering.
+     *
+     * @return string[] module names, e.g. ['mod_assign', 'mod_forum', ...]
+     */
+    public static function get_plagiarism_supported_modules() {
+        $mods = array_keys(core_component::get_plugin_list('mod'));
+        $supported = [];
+        foreach ($mods as $mod) {
+            if (plugin_supports('mod', $mod, FEATURE_PLAGIARISM)) {
+                $supported[] = 'mod_' . $mod;
+            }
+        }
+        sort($supported);
+        return $supported;
+    }
+
+    /**
+     * Get installed, FEATURE_PLAGIARISM-supporting modules that are enabled
+     * in the Turnitin plugin configuration page.
+     *
+     * @return string[] enabled module names in component format, e.g. ['mod_assign', 'mod_forum']
+     */
+    public static function get_enabled_supported_modules() {
+        $supported = self::get_plagiarism_supported_modules();
+        $enabled = [];
+        foreach ($supported as $mod) {
+            if (get_config('plagiarism_turnitin', 'plagiarism_turnitin_' . $mod)) {
+                $enabled[] = $mod;
+            }
+        }
+        return $enabled;
+    }
+
+    /**
+     * Load all cm=NULL config records for a given module name, stripping the
+     * {$modulename}_ prefix so the returned array is keyed by plain field names
+     * (e.g. 'use_turnitin', 'plagiarism_report_gen').
+     *
+     * This is the canonical implementation of the prefix-strip logic used both
+     * when displaying the Default Settings form and when pre-populating defaults
+     * for new activity instances.
+     *
+     * @param string $modulename Module name in component format, e.g. 'mod_assign'
+     * @return array<string, mixed> field name => stored value
+     */
+    public static function get_module_defaults(string $modulename): array {
+        global $DB;
+        $prefix      = $modulename . '_';
+        $prefixlen   = strlen($prefix);
+        $alldefaults = $DB->get_records('plagiarism_turnitin_config', ['cm' => null]);
+        $moddefaults = [];
+        foreach ($alldefaults as $record) {
+            if (strpos($record->name, $prefix) === 0) {
+                $moddefaults[substr($record->name, $prefixlen)] = $record->value;
+            }
+        }
+        return $moddefaults;
+    }
+
+    /**
      * Get the configuration settings for the plagiarism plugin
      *
      * @param string $modulename the name of the module
@@ -134,13 +195,31 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     /**
      * Get the Turnitin settings for a module
      *
-     * @param int $cmid - the course module id, if this is 0 the default settings will be retrieved
-     * @param bool $uselockedvalues - use locked values in place of saved values
-     * @return array of Turnitin settings for a module
+     * When $modulename is provided, per-module defaults are resolved via
+     * {@see self::get_module_defaults()} — the single canonical source of the
+     * prefix-strip logic — rather than repeating that logic inline.
+     *
+     * @param int    $cmid          The course module id; NULL loads defaults only.
+     * @param bool   $uselockedvalues Use locked values in place of saved values.
+     * @param string $modulename       Module name (e.g. 'mod_assign') to load per-modulee defaults;
+     *                                 when omitted all cm=NULL records are used.
+     * @return array Turnitin settings for the module (or defaults when $cmid is null).
      */
-    public function get_settings($cmid = null, $uselockedvalues = true) {
+    public function get_settings($cmid = null, $uselockedvalues = true, $modulename = '') {
         global $DB;
-        $defaults = $DB->get_records_menu('plagiarism_turnitin_config', ['cm' => null],     '', 'name,value');
+
+        if (!empty($modulename)) {
+            $defaults = self::get_module_defaults($modulename);
+        } else {
+            $defaults = $DB->get_records_menu('plagiarism_turnitin_config', ['cm' => null], '', 'name,value');
+        }
+
+        // When loading per-module defaults (no specific cmid), return the
+        // filtered defaults directly — the keys are already plain field names.
+        if ($cmid === null && !empty($modulename)) {
+            return $defaults;
+        }
+
         $settings = $DB->get_records_menu('plagiarism_turnitin_config', ['cm' => $cmid], '', 'name,value');
 
         // Don't overwrite settings with locked values (only relevant on inital module creation).
@@ -299,7 +378,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             }
 
             // Get assignment settings, use default settings on assignment creation.
-            $plagiarismvalues = $this->get_settings($cmid);
+            $plagiarismvalues = $this->get_settings($cmid, true, $modulename);
 
             /* If Turnitin is disabled and we don't have settings (we're editing an existing assignment
              * that was created without Turnitin enabled)
@@ -307,7 +386,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
              */
             if (empty($plagiarismvalues["use_turnitin"]) && count($plagiarismvalues) <= 2) {
                 $savedvalues = $plagiarismvalues;
-                $plagiarismvalues = $this->get_settings(null);
+                $plagiarismvalues = $this->get_settings(null, true, $modulename);
 
                 // Ensure we reuse the saved setting for use Turnitin.
                 if (isset($savedvalues["use_turnitin"])) {

--- a/lib.php
+++ b/lib.php
@@ -100,14 +100,36 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     /**
      * Get the fields to be used in the form to configure each activities Turnitin settings.
      *
+     * When $modulename is provided, plagiarism_draft_submit is only included if the
+     * module supports draft submissions (i.e. its DB table has a submissiondrafts column).
+     * When $modulename is omitted the field is always included.
+     *
+     * @param string $modulename Optional module name in component format, e.g. 'mod_assign'.
      * @return array of settings fields.
      */
-    public function get_settings_fields() {
-        return ['use_turnitin', 'plagiarism_show_student_report', 'plagiarism_draft_submit',
-            'plagiarism_allow_non_or_submissions', 'plagiarism_submitpapersto', 'plagiarism_compare_student_papers',
-            'plagiarism_compare_internet', 'plagiarism_compare_journals', 'plagiarism_report_gen',
-            'plagiarism_compare_institution', 'plagiarism_exclude_biblio', 'plagiarism_exclude_quoted',
-            'plagiarism_exclude_matches', 'plagiarism_exclude_matches_value', 'plagiarism_rubric', 'plagiarism_transmatch', ];
+    public function get_settings_fields(string $modulename = ''): array {
+        $fields = [];
+        if (empty($modulename) || self::module_supports_submission_drafts($modulename)) {
+            $fields[] = 'plagiarism_draft_submit';
+        }
+
+        return array_merge($fields, [
+            'use_turnitin',
+            'plagiarism_show_student_report',
+            'plagiarism_allow_non_or_submissions',
+            'plagiarism_submitpapersto',
+            'plagiarism_compare_student_papers',
+            'plagiarism_compare_internet',
+            'plagiarism_compare_journals',
+            'plagiarism_report_gen',
+            'plagiarism_compare_institution',
+            'plagiarism_exclude_biblio',
+            'plagiarism_exclude_quoted',
+            'plagiarism_exclude_matches',
+            'plagiarism_exclude_matches_value',
+            'plagiarism_rubric',
+            'plagiarism_transmatch',
+        ]);
     }
 
     /**
@@ -134,7 +156,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      *
      * @return string[] enabled module names in component format, e.g. ['mod_assign', 'mod_forum']
      */
-    public static function get_enabled_supported_modules() {
+    public static function get_enabled_supported_modules(): array {
         $supported = self::get_plagiarism_supported_modules();
         $enabled = [];
         foreach ($supported as $mod) {
@@ -172,6 +194,31 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     }
 
     /**
+     * Determine whether a module's database table contains a submissiondrafts column,
+     * meaning the module supports draft submissions.
+     *
+     * At activity level the form already contains the submissiondrafts element when
+     * applicable, so this method is primarily useful at the defaults level where no
+     * real activity form is instantiated.
+     *
+     * @param string $modulename Module name in component format, e.g. 'mod_assign'
+     * @return bool True if the module table has a submissiondrafts column.
+     */
+    public static function module_supports_submission_drafts(string $modulename): bool {
+        global $DB;
+        $modname = preg_replace('/^mod_/', '', $modulename);
+        if (empty($modname)) {
+            return false;
+        }
+        try {
+            $columns = $DB->get_columns($modname);
+        } catch (Exception $e) {
+            return false;
+        }
+        return array_key_exists('submissiondrafts', $columns);
+    }
+
+    /**
      * Get the configuration settings for the plagiarism plugin
      *
      * @param string $modulename the name of the module
@@ -201,33 +248,41 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      *
      * @param int    $cmid          The course module id; NULL loads defaults only.
      * @param bool   $uselockedvalues Use locked values in place of saved values.
-     * @param string $modulename       Module name (e.g. 'mod_assign') to load per-modulee defaults;
+     * @param string $modulename       Module name (e.g. 'mod_assign') to load per-module defaults;
      *                                 when omitted all cm=NULL records are used.
      * @return array Turnitin settings for the module (or defaults when $cmid is null).
      */
     public function get_settings($cmid = null, $uselockedvalues = true, $modulename = '') {
         global $DB;
 
+        // Find module name from cmid.
+        if (!empty($cmid)) {
+            $cm = get_coursemodule_from_id('', $cmid);
+            $modulename = $cm ? core_component::normalize_componentname($cm->modname) : '';
+        }
+
         if (!empty($modulename)) {
+            // Per-module defaults.
             $defaults = self::get_module_defaults($modulename);
         } else {
+            // All settings, includes all module defaults.
             $defaults = $DB->get_records_menu('plagiarism_turnitin_config', ['cm' => null], '', 'name,value');
         }
 
-        // When loading per-module defaults (no specific cmid), return the
-        // filtered defaults directly — the keys are already plain field names.
-        if ($cmid === null && !empty($modulename)) {
+        // Return defaults if $cmid is not specified.
+        if (empty($cmid)) {
             return $defaults;
         }
 
+        // Course module is specified, and the defaults are per-module.
         $settings = $DB->get_records_menu('plagiarism_turnitin_config', ['cm' => $cmid], '', 'name,value');
 
-        // Don't overwrite settings with locked values (only relevant on inital module creation).
+        // Don't overwrite settings with locked values (only relevant on initial module creation).
         if ($uselockedvalues == false) {
             return $settings;
         }
 
-        // Enforce site wide config locking.
+        // Enforce per-module config locking.
         foreach ($defaults as $key => $value) {
             if (substr($key, -5) !== '_lock') {
                 continue;
@@ -315,7 +370,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             return;
         }
 
-        $settingsfields = $this->get_settings_fields();
+        $settingsfields = $this->get_settings_fields('mod_' . $data->modulename);
         // Get current values.
         $plagiarismvalues = $this->get_settings($data->coursemodule, false);
 
@@ -394,7 +449,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 }
             }
 
-            $plagiarismelements = $this->get_settings_fields();
+            $plagiarismelements = $this->get_settings_fields($modulename);
 
             $turnitinview = new turnitin_view();
             $plagiarismvalues["plagiarism_rubric"] = ( !empty($plagiarismvalues["plagiarism_rubric"]) ) ?

--- a/settings.php
+++ b/settings.php
@@ -61,7 +61,7 @@ if (!empty($action)) {
         case "defaults":
             require_sesskey();
             $modulename = required_param('modulename', PARAM_ALPHANUMEXT);
-            $enabledmods = plagiarism_plugin_turnitin::get_enabled_supported_modules();
+            $enabledmods = $plagiarismpluginturnitin->get_enabled_supported_modules();
 
             // Validate modulename against enabled modules.
             if (!in_array($modulename, $enabledmods)) {
@@ -176,7 +176,7 @@ switch ($do) {
 
     case "defaults":
         $modulename = optional_param('modulename', '', PARAM_ALPHANUMEXT);
-        $enabledmods = plagiarism_plugin_turnitin::get_enabled_supported_modules();
+        $enabledmods = $plagiarismpluginturnitin->get_enabled_supported_modules();
 
         $turnitinview->draw_settings_tab_menu('turnitindefaults', $notice);
 
@@ -203,7 +203,7 @@ switch ($do) {
 
         // Load the per-module defaults from the DB, stripping the module name prefix
         // so field names match the form element names.
-        $moddefaults = plagiarism_plugin_turnitin::get_module_defaults($modulename);
+        $moddefaults = $plagiarismpluginturnitin->get_module_defaults($modulename);
 
         $mform->set_data($moddefaults);
         $mform->display();

--- a/settings.php
+++ b/settings.php
@@ -59,6 +59,14 @@ $plugindefaults = $plagiarismpluginturnitin->get_settings();
 if (!empty($action)) {
     switch ($action) {
         case "defaults":
+            $modulename = required_param('modulename', PARAM_ALPHANUMEXT);
+            $enabledmods = $plagiarismpluginturnitin->get_enabled_supported_modules();
+
+            // Validate modulename against enabled modules.
+            if (!in_array($modulename, $enabledmods)) {
+                plagiarism_turnitin_print_error('invalidmodtype');
+            }
+
             $fields = $plagiarismpluginturnitin->get_settings_fields();
 
             $settingsfields = [];
@@ -69,18 +77,21 @@ if (!empty($action)) {
             array_push($settingsfields, 'plagiarism_locked_message');
 
             foreach ($settingsfields as $field) {
+                // Store using {$modulename}_{fieldname} convention.
+                $storedname = $modulename . '_' . $field;
+
                 $defaultfield = new stdClass();
                 $defaultfield->cm = null;
-                $defaultfield->name = $field;
+                $defaultfield->name = $storedname;
                 if ($field == 'plagiarism_locked_message') {
                     $defaultfield->value = optional_param($field, '', PARAM_TEXT);
                 } else {
                     $defaultfield->value = optional_param($field, '', PARAM_ALPHANUMEXT);
                 }
 
-                if (isset($plugindefaults[$field])) {
+                if (isset($plugindefaults[$storedname])) {
                     $defaultfield->id = $DB->get_field('plagiarism_turnitin_config', 'id',
-                                                (['cm' => null, 'name' => $field]));
+                                                (['cm' => null, 'name' => $storedname]));
                     if (!$DB->update_record('plagiarism_turnitin_config', $defaultfield)) {
                         plagiarism_turnitin_print_error('defaultupdateerror', 'plagiarism_turnitin', null,
                             null, __FILE__, __LINE__);
@@ -95,7 +106,13 @@ if (!empty($action)) {
             }
 
             $_SESSION['notice']['message'] = get_string('defaultupdated', 'plagiarism_turnitin');
-            redirect(new moodle_url('/plagiarism/turnitin/settings.php', ['do' => 'defaults']));
+            redirect(new moodle_url(
+                '/plagiarism/turnitin/settings.php',
+                [
+                    'do' => 'defaults',
+                    'modulename' => $modulename,
+                ]
+            ));
             exit;
             break;
 
@@ -156,12 +173,37 @@ switch ($do) {
         break;
 
     case "defaults":
+        $modulename = optional_param('modulename', '', PARAM_ALPHANUMEXT);
+        $enabledmods = $plagiarismpluginturnitin->get_enabled_supported_modules();
+
         $turnitinview->draw_settings_tab_menu('turnitindefaults', $notice);
+
+        if (empty($enabledmods)) {
+            // No modules enabled — show a prompt to enable one on the config page.
+            echo $OUTPUT->notification(get_string('noenabledmodules', 'plagiarism_turnitin'), 'info');
+            break;
+        }
+
+        // Validate / default the active module tab.
+        if (empty($modulename) || !in_array($modulename, $enabledmods)) {
+            $modulename = $enabledmods[0];
+        }
+
+        // Draw subtab for each module, and show the current selected module.
+        $turnitinview->draw_defaults_subtab_menu($modulename);
 
         require_once($CFG->dirroot.'/plagiarism/turnitin/classes/forms/turnitin_defaultsettingsform.class.php');
 
-        $mform = new turnitin_defaultsettingsform($CFG->wwwroot.'/plagiarism/turnitin/settings.php?do=defaults');
-        $mform->set_data($plugindefaults);
+        $mform = new turnitin_defaultsettingsform(
+            $CFG->wwwroot . '/plagiarism/turnitin/settings.php?do=defaults&modulename=' . $modulename,
+            ['modulename' => $modulename]
+        );
+
+        // Load the per-module defaults from the DB, stripping the module name prefix
+        // so field names match the form element names.
+        $moddefaults = plagiarism_plugin_turnitin::get_module_defaults($modulename);
+
+        $mform->set_data($moddefaults);
         $mform->display();
         break;
 

--- a/settings.php
+++ b/settings.php
@@ -59,15 +59,16 @@ $plugindefaults = $plagiarismpluginturnitin->get_settings();
 if (!empty($action)) {
     switch ($action) {
         case "defaults":
+            require_sesskey();
             $modulename = required_param('modulename', PARAM_ALPHANUMEXT);
-            $enabledmods = $plagiarismpluginturnitin->get_enabled_supported_modules();
+            $enabledmods = plagiarism_plugin_turnitin::get_enabled_supported_modules();
 
             // Validate modulename against enabled modules.
             if (!in_array($modulename, $enabledmods)) {
                 plagiarism_turnitin_print_error('invalidmodtype');
             }
 
-            $fields = $plagiarismpluginturnitin->get_settings_fields();
+            $fields = $plagiarismpluginturnitin->get_settings_fields($modulename);
 
             $settingsfields = [];
             foreach ($fields as $field) {
@@ -117,6 +118,7 @@ if (!empty($action)) {
             break;
 
         case "deletefile":
+            require_sesskey();
             $id = optional_param('id', 0, PARAM_INT);
             $DB->update_record('plagiarism_turnitin_files', ['id' => $id, 'statuscode' => "deleted"]);
             redirect(new moodle_url('/plagiarism/turnitin/settings.php', ['do' => 'errors']));
@@ -174,7 +176,7 @@ switch ($do) {
 
     case "defaults":
         $modulename = optional_param('modulename', '', PARAM_ALPHANUMEXT);
-        $enabledmods = $plagiarismpluginturnitin->get_enabled_supported_modules();
+        $enabledmods = plagiarism_plugin_turnitin::get_enabled_supported_modules();
 
         $turnitinview->draw_settings_tab_menu('turnitindefaults', $notice);
 

--- a/tests/default_settings_per_module_test.php
+++ b/tests/default_settings_per_module_test.php
@@ -1,0 +1,360 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for per-module default settings feature.
+ *
+ * Tests cover:
+ *  - get_plagiarism_supported_modules()
+ *  - get_enabled_supported_modules()
+ *  - get_settings() with a module (loading per-module defaults)
+ *  - get_settings() lock enforcement using per-module lock records
+ *  - get_settings() for an existing activity with per-module lock override
+ *  - Saving per-module defaults to plagiarism_turnitin_config
+ *  - Loading per-module defaults for display (prefix-strip logic)
+ *  - Isolation: module defaults do not bleed into other modules
+ *
+ * @package    plagiarism_turnitin
+ * @copyright  2026 Monash University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace plagiarism_turnitin;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/plagiarism/turnitin/lib.php');
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+
+/**
+ * Tests for per-module default settings.
+ *
+ * @package plagiarism_turnitin
+ */
+#[CoversFunction('plagiarism_plugin_turnitin::get_plagiarism_supported_modules')]
+#[CoversFunction('plagiarism_plugin_turnitin::get_enabled_supported_modules')]
+#[CoversFunction('plagiarism_plugin_turnitin::get_settings')]
+#[CoversFunction('plagiarism_plugin_turnitin::get_module_defaults')]
+final class default_settings_per_module_test extends \advanced_testcase {
+
+    /** @var \plagiarism_plugin_turnitin */
+    private \plagiarism_plugin_turnitin $plugin;
+
+    /**
+     * Set up before each test.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+        $this->plugin = new \plagiarism_plugin_turnitin();
+    }
+
+    /**
+     * Insert a cm=NULL config record using an already-prefixed name.
+     *
+     * @param string $name  e.g. 'assign_use_turnitin'
+     * @param mixed  $value
+     */
+    private function insert_default(string $name, $value): void {
+        global $DB;
+        $record              = new \stdClass();
+        $record->cm          = null;
+        $record->name        = $name;
+        $record->value       = $value;
+        $record->config_hash = 'null_' . $name;
+        $DB->insert_record('plagiarism_turnitin_config', $record);
+    }
+
+    /**
+     * Insert a per-activity config record.
+     *
+     * @param int    $cmid
+     * @param string $name  plain field name, e.g. 'use_turnitin'
+     * @param mixed  $value
+     */
+    private function insert_cm_setting(int $cmid, string $name, $value): void {
+        global $DB;
+        $record              = new \stdClass();
+        $record->cm          = $cmid;
+        $record->name        = $name;
+        $record->value       = $value;
+        $record->config_hash = $cmid . '_' . $name;
+        $DB->insert_record('plagiarism_turnitin_config', $record);
+    }
+
+    /**
+     * Enable a module in the Turnitin plugin config.
+     *
+     * @param string $modulename module name e.g. 'mod_assign' (the admin config key uses the bare name)
+     */
+    private function enable_module(string $modulename): void {
+        set_config('plagiarism_turnitin_' . $modulename, 1, 'plagiarism_turnitin');
+    }
+
+    /**
+     * Test that the returned list is sorted alphabetically.
+     */
+    public function test_get_plagiarism_supported_modules_is_sorted(): void {
+        $modules = \plagiarism_plugin_turnitin::get_plagiarism_supported_modules();
+        $sorted  = $modules;
+        sort($sorted);
+
+        $this->assertEquals($sorted, $modules, 'Supported modules list should be sorted alphabetically');
+    }
+
+    /**
+     * Test that known supported modules (assign, forum) are present.
+     * Note: get_plagiarism_supported_modules() still returns bare names
+     * (used internally for config key lookups).
+     */
+    public function test_get_plagiarism_supported_modules_contains_known_modules(): void {
+        $modules = \plagiarism_plugin_turnitin::get_plagiarism_supported_modules();
+
+        $this->assertContains('mod_assign', $modules);
+        $this->assertContains('mod_forum', $modules);
+    }
+
+    /**
+     * Test that no modules are returned when none are enabled.
+     */
+    public function test_get_enabled_supported_modules_empty_when_none_enabled(): void {
+        $enabled = \plagiarism_plugin_turnitin::get_enabled_supported_modules();
+
+        $this->assertIsArray($enabled);
+        $this->assertEmpty($enabled);
+    }
+
+    /**
+     * Test that only the explicitly enabled module appears.
+     * get_enabled_supported_modules() returns component-format names e.g. 'mod_assign'.
+     */
+    public function test_get_enabled_supported_modules_returns_enabled_only(): void {
+        $this->enable_module('mod_assign');
+
+        $enabled = \plagiarism_plugin_turnitin::get_enabled_supported_modules();
+
+        $this->assertContains('mod_assign', $enabled);
+        $this->assertNotContains('mod_forum', $enabled);
+    }
+
+    /**
+     * Test that multiple enabled modules all appear.
+     */
+    public function test_get_enabled_supported_modules_multiple_enabled(): void {
+        $this->enable_module('mod_assign');
+        $this->enable_module('mod_forum');
+
+        $enabled = \plagiarism_plugin_turnitin::get_enabled_supported_modules();
+
+        $this->assertContains('mod_assign', $enabled);
+        $this->assertContains('mod_forum', $enabled);
+    }
+
+    /**
+     * Test that a module not declaring FEATURE_PLAGIARISM is never returned
+     * even if its config key is set.
+     */
+    public function test_get_enabled_supported_modules_ignores_non_plagiarism_modules(): void {
+        // Mod 'resource' does not declare FEATURE_PLAGIARISM.
+        set_config('plagiarism_turnitin_mod_resource', 1, 'plagiarism_turnitin');
+
+        $enabled = \plagiarism_plugin_turnitin::get_enabled_supported_modules();
+
+        $this->assertNotContains('mod_resource', $enabled);
+    }
+
+    /**
+     * Test that get_settings(null, true, 'mod_assign') returns mod_assign-prefixed
+     * records with the prefix stripped.
+     */
+    public function test_get_settings_returns_module_defaults_stripped(): void {
+        $this->insert_default('mod_assign_use_turnitin', 1);
+        $this->insert_default('mod_assign_plagiarism_show_student_report', 0);
+        // Forum record must NOT bleed through.
+        $this->insert_default('mod_forum_use_turnitin', 0);
+
+        $settings = $this->plugin->get_settings(null, true, 'mod_assign');
+
+        $this->assertArrayHasKey('use_turnitin', $settings);
+        $this->assertEquals(1, $settings['use_turnitin']);
+        $this->assertArrayHasKey('plagiarism_show_student_report', $settings);
+        $this->assertEquals(0, $settings['plagiarism_show_student_report']);
+        $this->assertArrayNotHasKey('mod_forum_use_turnitin', $settings);
+    }
+
+    /**
+     * Test that mod_assign and mod_forum modules return different values for the
+     * same field when they have different defaults stored.
+     */
+    public function test_get_settings_isolates_module_defaults(): void {
+        $this->insert_default('mod_assign_use_turnitin', 1);
+        $this->insert_default('mod_forum_use_turnitin', 0);
+
+        $assignsettings = $this->plugin->get_settings(null, true, 'mod_assign');
+        $forumsettings  = $this->plugin->get_settings(null, true, 'mod_forum');
+
+        $this->assertEquals(1, $assignsettings['use_turnitin']);
+        $this->assertEquals(0, $forumsettings['use_turnitin']);
+    }
+
+    /**
+     * Test that calling get_settings without a module returns all cm=NULL
+.     */
+    public function test_get_settings_without_module_returns_all_defaults(): void {
+        $this->insert_default('mod_assign_use_turnitin', 1);
+        $this->insert_default('mod_forum_use_turnitin', 0);
+
+        $settings = $this->plugin->get_settings();
+
+        $this->assertArrayHasKey('mod_assign_use_turnitin', $settings);
+        $this->assertArrayHasKey('mod_forum_use_turnitin', $settings);
+    }
+
+    /**
+     * Test that a locked mod_assign default overrides an activity's own value.
+     */
+    public function test_get_settings_lock_overrides_activity_value(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $assign = $this->getDataGenerator()->create_module('assign', ['course' => $course->id]);
+        $cm     = get_coursemodule_from_instance('assign', $assign->id);
+
+        // Activity stores use_turnitin = 0.
+        $this->insert_cm_setting($cm->id, 'use_turnitin', 0);
+
+        // Per-module default locked to 1.
+        $this->insert_default('mod_assign_use_turnitin', 1);
+        $this->insert_default('mod_assign_use_turnitin_lock', 1);
+
+        $settings = $this->plugin->get_settings($cm->id, true, 'mod_assign');
+
+        // Lock must override activity's 0 → enforce 1.
+        $this->assertEquals(1, $settings['use_turnitin']);
+    }
+
+    /**
+     * Test that an unlocked default does NOT override an activity's own value.
+     */
+    public function test_get_settings_unlocked_default_does_not_override(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $assign = $this->getDataGenerator()->create_module('assign', ['course' => $course->id]);
+        $cm     = get_coursemodule_from_instance('assign', $assign->id);
+
+        $this->insert_cm_setting($cm->id, 'plagiarism_compare_internet', 0);
+
+        // Default says 1 but lock = 0 (not locked).
+        $this->insert_default('mod_assign_plagiarism_compare_internet', 1);
+        $this->insert_default('mod_assign_plagiarism_compare_internet_lock', 0);
+
+        $settings = $this->plugin->get_settings($cm->id, true, 'mod_assign');
+
+        // Activity's own 0 must be preserved.
+        $this->assertEquals(0, $settings['plagiarism_compare_internet']);
+    }
+
+    /**
+     * Test get_settings should show course module settings, not default settings.
+     */
+    public function test_get_settings_use_locked_values_false_skips_enforcement(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $assign = $this->getDataGenerator()->create_module('assign', ['course' => $course->id]);
+        $cm     = get_coursemodule_from_instance('assign', $assign->id);
+
+        $this->insert_cm_setting($cm->id, 'use_turnitin', 0);
+        $this->insert_default('mod_assign_use_turnitin', 1);
+        $this->insert_default('mod_assign_use_turnitin_lock', 1);
+
+        $settings = $this->plugin->get_settings($cm->id, false, 'mod_assign');
+
+        // Activity's own value is returned.
+        $this->assertEquals(0, $settings['use_turnitin']);
+    }
+
+    /**
+     * Test that the display loading logic strips the module prefix correctly
+     * and excludes records from other modules.
+     */
+    public function test_display_loading_strips_prefix(): void {
+        $this->insert_default('mod_assign_use_turnitin', 1);
+        $this->insert_default('mod_assign_plagiarism_show_student_report', 0);
+        $this->insert_default('mod_assign_plagiarism_locked_message', 'Locked by admin');
+        $this->insert_default('mod_forum_use_turnitin', 0);
+
+        $moddefaults = \plagiarism_plugin_turnitin::get_module_defaults('mod_assign');
+
+        $this->assertArrayHasKey('use_turnitin', $moddefaults);
+        $this->assertEquals(1, $moddefaults['use_turnitin']);
+        $this->assertArrayHasKey('plagiarism_show_student_report', $moddefaults);
+        $this->assertEquals(0, $moddefaults['plagiarism_show_student_report']);
+        $this->assertArrayHasKey('plagiarism_locked_message', $moddefaults);
+        $this->assertEquals('Locked by admin', $moddefaults['plagiarism_locked_message']);
+
+        // Forum key and prefixed key must not appear.
+        $this->assertArrayNotHasKey('mod_forum_use_turnitin', $moddefaults);
+        $this->assertArrayNotHasKey('mod_assign_use_turnitin', $moddefaults);
+    }
+
+    /**
+     * Test display loading returns an empty array when no records exist for
+     * the requested module.
+     */
+    public function test_display_loading_empty_for_unknown_module(): void {
+        $this->insert_default('mod_assign_use_turnitin', 1);
+
+        $moddefaults = \plagiarism_plugin_turnitin::get_module_defaults('mod_quiz');
+
+        $this->assertEmpty($moddefaults);
+    }
+
+    /**
+     * Test a full round-trip: write per-module defaults, then read them back
+     * via get_settings and confirm values are correct.
+     */
+    public function test_round_trip_save_and_load_defaults(): void {
+        $this->insert_default('mod_assign_use_turnitin', 1);
+        $this->insert_default('mod_assign_plagiarism_report_gen', 2);
+        $this->insert_default('mod_assign_plagiarism_compare_internet', 1);
+        $this->insert_default('mod_assign_plagiarism_compare_student_papers', 0);
+
+        $settings = $this->plugin->get_settings(null, true, 'mod_assign');
+
+        $this->assertEquals(1, $settings['use_turnitin']);
+        $this->assertEquals(2, $settings['plagiarism_report_gen']);
+        $this->assertEquals(1, $settings['plagiarism_compare_internet']);
+        $this->assertEquals(0, $settings['plagiarism_compare_student_papers']);
+    }
+
+    /**
+     * Test that mod_assign and mod_forum return independent default sets after writing
+     * different values for each.
+     */
+    public function test_round_trip_independent_defaults_per_module(): void {
+        $this->insert_default('mod_assign_use_turnitin', 1);
+        $this->insert_default('mod_assign_plagiarism_compare_internet', 1);
+
+        $this->insert_default('mod_forum_use_turnitin', 0);
+        $this->insert_default('mod_forum_plagiarism_compare_internet', 0);
+
+        $assign = $this->plugin->get_settings(null, true, 'mod_assign');
+        $forum  = $this->plugin->get_settings(null, true, 'mod_forum');
+
+        $this->assertEquals(1, $assign['use_turnitin']);
+        $this->assertEquals(1, $assign['plagiarism_compare_internet']);
+        $this->assertEquals(0, $forum['use_turnitin']);
+        $this->assertEquals(0, $forum['plagiarism_compare_internet']);
+    }
+}

--- a/tests/default_settings_per_module_test.php
+++ b/tests/default_settings_per_module_test.php
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace plagiarism_turnitin;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/plagiarism/turnitin/lib.php');
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+
 /**
  * Unit tests for per-module default settings feature.
  *
@@ -28,30 +37,14 @@
  *  - Isolation: module defaults do not bleed into other modules
  *
  * @package    plagiarism_turnitin
- * @copyright  2026 Monash University
+ * @copyright  2026 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-namespace plagiarism_turnitin;
-
-defined('MOODLE_INTERNAL') || die();
-
-global $CFG;
-require_once($CFG->dirroot . '/plagiarism/turnitin/lib.php');
-
-use PHPUnit\Framework\Attributes\CoversFunction;
-
-/**
- * Tests for per-module default settings.
- *
- * @package plagiarism_turnitin
  */
 #[CoversFunction('plagiarism_plugin_turnitin::get_plagiarism_supported_modules')]
 #[CoversFunction('plagiarism_plugin_turnitin::get_enabled_supported_modules')]
 #[CoversFunction('plagiarism_plugin_turnitin::get_settings')]
 #[CoversFunction('plagiarism_plugin_turnitin::get_module_defaults')]
 final class default_settings_per_module_test extends \advanced_testcase {
-
     /** @var \plagiarism_plugin_turnitin */
     private \plagiarism_plugin_turnitin $plugin;
 
@@ -76,7 +69,7 @@ final class default_settings_per_module_test extends \advanced_testcase {
         $record->cm          = null;
         $record->name        = $name;
         $record->value       = $value;
-        $record->config_hash = 'null_' . $name;
+        $record->config_hash = $record->cm . $record->name;
         $DB->insert_record('plagiarism_turnitin_config', $record);
     }
 
@@ -118,15 +111,32 @@ final class default_settings_per_module_test extends \advanced_testcase {
     }
 
     /**
-     * Test that known supported modules (assign, forum) are present.
-     * Note: get_plagiarism_supported_modules() still returns bare names
-     * (used internally for config key lookups).
+     * Test that every module returned by get_plagiarism_supported_modules() actually
+     * declares FEATURE_PLAGIARISM, and that at least one such module is present,
+     * and the module names contain prefix mod_.
      */
     public function test_get_plagiarism_supported_modules_contains_known_modules(): void {
+        // Dynamically collect all installed modules that declare FEATURE_PLAGIARISM.
+        $expectedmodules = [];
+        foreach (array_keys(\core_component::get_plugin_list('mod')) as $mod) {
+            if (plugin_supports('mod', $mod, FEATURE_PLAGIARISM)) {
+                $expectedmodules[] = 'mod_' . $mod;
+            }
+        }
+
+        if (empty($expectedmodules)) {
+            $this->markTestSkipped('No installed module declares FEATURE_PLAGIARISM support.');
+        }
+
         $modules = \plagiarism_plugin_turnitin::get_plagiarism_supported_modules();
 
-        $this->assertContains('mod_assign', $modules);
-        $this->assertContains('mod_forum', $modules);
+        foreach ($expectedmodules as $modcomponent) {
+            $this->assertContains(
+                $modcomponent,
+                $modules,
+                "Module '$modcomponent' declares FEATURE_PLAGIARISM but is missing from get_plagiarism_supported_modules()."
+            );
+        }
     }
 
     /**
@@ -148,6 +158,7 @@ final class default_settings_per_module_test extends \advanced_testcase {
 
         $enabled = \plagiarism_plugin_turnitin::get_enabled_supported_modules();
 
+        $this->assertCount(1, $enabled);
         $this->assertContains('mod_assign', $enabled);
         $this->assertNotContains('mod_forum', $enabled);
     }
@@ -161,6 +172,7 @@ final class default_settings_per_module_test extends \advanced_testcase {
 
         $enabled = \plagiarism_plugin_turnitin::get_enabled_supported_modules();
 
+        $this->assertCount(2, $enabled);
         $this->assertContains('mod_assign', $enabled);
         $this->assertContains('mod_forum', $enabled);
     }
@@ -170,12 +182,29 @@ final class default_settings_per_module_test extends \advanced_testcase {
      * even if its config key is set.
      */
     public function test_get_enabled_supported_modules_ignores_non_plagiarism_modules(): void {
-        // Mod 'resource' does not declare FEATURE_PLAGIARISM.
-        set_config('plagiarism_turnitin_mod_resource', 1, 'plagiarism_turnitin');
+        // Dynamically locate the first installed module that does NOT declare FEATURE_PLAGIARISM.
+        $nonsupportingmod = null;
+        foreach (array_keys(\core_component::get_plugin_list('mod')) as $mod) {
+            if (!plugin_supports('mod', $mod, FEATURE_PLAGIARISM)) {
+                $nonsupportingmod = $mod;
+                break;
+            }
+        }
+
+        if ($nonsupportingmod === null) {
+            $this->markTestSkipped('No installed module found that lacks FEATURE_PLAGIARISM support.');
+        }
+
+        $modcomponent = 'mod_' . $nonsupportingmod;
+        set_config('plagiarism_turnitin_' . $modcomponent, 1, 'plagiarism_turnitin');
 
         $enabled = \plagiarism_plugin_turnitin::get_enabled_supported_modules();
 
-        $this->assertNotContains('mod_resource', $enabled);
+        $this->assertNotContains(
+            $modcomponent,
+            $enabled,
+            "Module '$modcomponent' does not declare FEATURE_PLAGIARISM and must not appear in enabled modules."
+        );
     }
 
     /**
@@ -214,7 +243,7 @@ final class default_settings_per_module_test extends \advanced_testcase {
 
     /**
      * Test that calling get_settings without a module returns all cm=NULL
-.     */
+     */
     public function test_get_settings_without_module_returns_all_defaults(): void {
         $this->insert_default('mod_assign_use_turnitin', 1);
         $this->insert_default('mod_forum_use_turnitin', 0);

--- a/tests/default_settings_per_module_test.php
+++ b/tests/default_settings_per_module_test.php
@@ -103,7 +103,7 @@ final class default_settings_per_module_test extends \advanced_testcase {
      * Test that the returned list is sorted alphabetically.
      */
     public function test_get_plagiarism_supported_modules_is_sorted(): void {
-        $modules = \plagiarism_plugin_turnitin::get_plagiarism_supported_modules();
+        $modules = $this->plugin->get_plagiarism_supported_modules();
         $sorted  = $modules;
         sort($sorted);
 
@@ -128,7 +128,7 @@ final class default_settings_per_module_test extends \advanced_testcase {
             $this->markTestSkipped('No installed module declares FEATURE_PLAGIARISM support.');
         }
 
-        $modules = \plagiarism_plugin_turnitin::get_plagiarism_supported_modules();
+        $modules = $this->plugin->get_plagiarism_supported_modules();
 
         foreach ($expectedmodules as $modcomponent) {
             $this->assertContains(
@@ -143,7 +143,7 @@ final class default_settings_per_module_test extends \advanced_testcase {
      * Test that no modules are returned when none are enabled.
      */
     public function test_get_enabled_supported_modules_empty_when_none_enabled(): void {
-        $enabled = \plagiarism_plugin_turnitin::get_enabled_supported_modules();
+        $enabled = $this->plugin->get_enabled_supported_modules();
 
         $this->assertIsArray($enabled);
         $this->assertEmpty($enabled);
@@ -156,7 +156,7 @@ final class default_settings_per_module_test extends \advanced_testcase {
     public function test_get_enabled_supported_modules_returns_enabled_only(): void {
         $this->enable_module('mod_assign');
 
-        $enabled = \plagiarism_plugin_turnitin::get_enabled_supported_modules();
+        $enabled = $this->plugin->get_enabled_supported_modules();
 
         $this->assertCount(1, $enabled);
         $this->assertContains('mod_assign', $enabled);
@@ -170,7 +170,7 @@ final class default_settings_per_module_test extends \advanced_testcase {
         $this->enable_module('mod_assign');
         $this->enable_module('mod_forum');
 
-        $enabled = \plagiarism_plugin_turnitin::get_enabled_supported_modules();
+        $enabled = $this->plugin->get_enabled_supported_modules();
 
         $this->assertCount(2, $enabled);
         $this->assertContains('mod_assign', $enabled);
@@ -198,7 +198,7 @@ final class default_settings_per_module_test extends \advanced_testcase {
         $modcomponent = 'mod_' . $nonsupportingmod;
         set_config('plagiarism_turnitin_' . $modcomponent, 1, 'plagiarism_turnitin');
 
-        $enabled = \plagiarism_plugin_turnitin::get_enabled_supported_modules();
+        $enabled = $this->plugin->get_enabled_supported_modules();
 
         $this->assertNotContains(
             $modcomponent,
@@ -323,7 +323,7 @@ final class default_settings_per_module_test extends \advanced_testcase {
         $this->insert_default('mod_assign_plagiarism_locked_message', 'Locked by admin');
         $this->insert_default('mod_forum_use_turnitin', 0);
 
-        $moddefaults = \plagiarism_plugin_turnitin::get_module_defaults('mod_assign');
+        $moddefaults = $this->plugin->get_module_defaults('mod_assign');
 
         $this->assertArrayHasKey('use_turnitin', $moddefaults);
         $this->assertEquals(1, $moddefaults['use_turnitin']);
@@ -344,7 +344,7 @@ final class default_settings_per_module_test extends \advanced_testcase {
     public function test_display_loading_empty_for_unknown_module(): void {
         $this->insert_default('mod_assign_use_turnitin', 1);
 
-        $moddefaults = \plagiarism_plugin_turnitin::get_module_defaults('mod_quiz');
+        $moddefaults = $this->plugin->get_module_defaults('mod_quiz');
 
         $this->assertEmpty($moddefaults);
     }

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2026060201.03;
+$plugin->version = 2026062400.01;
 
 $plugin->release = "4.1+";
 $plugin->requires = 2018051700;

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2026062400.01;
+$plugin->version = 2026060201.04;
 
 $plugin->release = "4.1+";
 $plugin->requires = 2018051700;


### PR DESCRIPTION
issue https://github.com/turnitin/moodle-plagiarism_turnitin/issues/949

Testing instruction:

1. Test the Default Settings admin UI 
- Go to Site admin → Plugins → Plagiarism  → Turnitin → Defaults tab )
- With at least two modules enabled (e.g. mod_assign and mod_forum)
- Confirm per-module sub tabs 

2 . Test saving and lock enforcement
- On the Defaults tab
- Set use_turnitin=1 with lock enabled for mod_assign
- And use_turnitin=0 with no lock for mod_forum. 
- Save both.
- Create a new Assignment and a new Forum
- The Assignment's use_turnitin is forced to 1 (locked), 
- While the Forum activity retains its own saved value of 0 (not locked).

3. Test isolation between modules 
- Confirm that changing defaults on the mod_assign subtab does not alter the saved defaults for mod_forum

4. No enabled modules 
- Disable all modules in the Turnitin config page
- Navigate to the Defaults tab
- Confirm the a notification is shown rather than a blank page or error.